### PR TITLE
Add LightYear

### DIFF
--- a/length.go
+++ b/length.go
@@ -48,6 +48,7 @@ const (
 	// space
 	LunarDistance    = Kilometer * 384400
 	AstronomicalUnit = Meter * 149597870700
+	LightYear        = Meter * 9460730472580800
 )
 
 // Yoctometers returns the length in ym
@@ -228,4 +229,9 @@ func (l Length) LunarDistances() float64 {
 // AstronomicalUnits returns the length in au
 func (l Length) AstronomicalUnits() float64 {
 	return float64(l / AstronomicalUnit)
+}
+
+// LightYears returns the length in ly
+func (l Length) LightYears() float64 {
+	return float64(l / LightYears)
 }

--- a/length.go
+++ b/length.go
@@ -233,5 +233,5 @@ func (l Length) AstronomicalUnits() float64 {
 
 // LightYears returns the length in ly
 func (l Length) LightYears() float64 {
-	return float64(l / LightYears)
+	return float64(l / LightYear)
 }

--- a/length_test.go
+++ b/length_test.go
@@ -58,4 +58,5 @@ func TestLength(t *testing.T) {
 	// space
 	assert.Equal(t, 389.17240036420395, (1 * AstronomicalUnit).LunarDistances())
 	assert.Equal(t, 0.0025695552897999903, (1 * LunarDistance).AstronomicalUnits())
+	assert.Equal(t, 63241.07708426628, (1 * LightYear).AstronomicalUnits())
 }


### PR DESCRIPTION
Adds a `LightYear` constant, and `LightYears` getter, to the `Length` type.

The value given is per https://www.iau.org/public/themes/measuring/. 