### PR TITLE
Added unit for pressure, inch of mercury

### DIFF
--- a/pressure.go
+++ b/pressure.go
@@ -55,6 +55,7 @@ const (
 	TechAtmosphere      = Pascal * 9.80665 * 1e4
 	Torr                = Pascal * 133.3224
 	PoundsPerSquareInch = Pascal * 6.8948 * 1e3
+	InchOfMercury       = Pascal * 3386.389
 )
 
 // Yoctopascals returns the pressure in yPa
@@ -285,4 +286,9 @@ func (p Pressure) Torrs() float64 {
 // PoundsPerSquareInch returns the pressure in psi
 func (p Pressure) PoundsPerSquareInch() float64 {
 	return float64(p / PoundsPerSquareInch)
+}
+
+// InchOfMercury returns the pressure in inch of mercury
+func (p Pressure) InchOfMercury() float64 {
+	return float64(p / InchOfMercury)
 }

--- a/pressure_test.go
+++ b/pressure_test.go
@@ -61,4 +61,5 @@ func TestPressure(t *testing.T) {
 	assertFloatEqual(t, 0.10197162129779283, (10000 * Pascal).TechAtmospheres())
 	assertFloatEqual(t, 75.00615050434136, (10000 * Pascal).Torrs())
 	assertFloatEqual(t, 1.4503683935719673, (10000 * Pascal).PoundsPerSquareInch())
+	assertFloatEqual(t, 2.9529980164712323, (10000 * Pascal).InchOfMercury())
 }


### PR DESCRIPTION
Added inch of mercury as a unit for pressure, more info at <https://en.wikipedia.org/wiki/Inch_of_mercury>. I use it to convert data from NMEA0183 sentences, the specific sentence is <http://www.nuovamarea.net/blog/wimda>.